### PR TITLE
Add `prop-types` as dependency requirement

### DIFF
--- a/milestones/MILESTONE_1.md
+++ b/milestones/MILESTONE_1.md
@@ -8,9 +8,10 @@ You need to build the foundation of your project, and because this project does 
 1. Use `create-react-app` to initialize a new React app
     - Documentation: [https://github.com/facebook/create-react-app](https://github.com/facebook/create-react-app)
 2. Delete any unnecessary file or asset
-3. Add the necessary Redux packages to your project:
+3. Add the necessary packages to your project:
     - Add `react-redux` using npm.
     - Add `redux` using npm.
+    - Add [`prop-types`](https://www.npmjs.com/package/prop-types) using npm for [typechecking props](https://reactjs.org/docs/typechecking-with-proptypes.html).
 4. Run the application with `npm start` and make sure that everything works correctly.
 5. Follow the instructions in `create-react-app-buildpack` to deploy the app to Heroku
     - Initialize a git repo


### PR DESCRIPTION
## Description of issue

[As discussed](https://gitlab.com/microverse/guides/tse/code_review/code_review_guidelines/issues/37), since the requirements have milestones that involve making `prop` a certain type. e.g. the `Display` component is required to have a `result` prop of type `String`. 

Also, ESlint enforces this, but students disable this rule sometimes.

I would recommend adding `prop-type` and also using it as the required type checker for React projects.
More on `prop-type` https://reactjs.org/docs/typechecking-with-proptypes.html

## Proposed Solution

This PR address this issue by adding the requirement.
